### PR TITLE
Config-Page + Übersetzungen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -5,14 +5,26 @@
 demo_addon_title = Demo-Addon
 
 demo_addon_main = Hauptseite
+demo_addon_main_title = Demo-Addon Titel Hauptseite
+demo_addon_main_content = Inhalt Demo-Addon-Seite
 
 demo_addon_config = Einstellungen
+demo_addon_config_legend1 = Einfache Felder
 demo_addon_config_url = URL
-demo_addon_config_ids = IDs
+demo_addon_config_checkbox = Checkbox
+demo_addon_config_select = Select
+demo_addon_config_multiselect = Multiselect
+
+demo_addon_config_legend2 = Medienpool, Linkmap usw.
+demo_addon_config_file = Datei
+demo_addon_config_article = Artikel
+demo_addon_config_categories = Kategorienauswahl
+demo_addon_config_pageids = Seitenauswahl
+
 demo_addon_config_save = Einstellungen speichern
 demo_addon_config_saved = Einstellungen wurden gespeichert!
 
 # Benennung für die Addonrechte, sichtbar innerhalb der REDAXO-Administration unter Benutzer > Rollen > Allgemein
 
-perm_general_demo_addon[] = Rechte für Demo-Addon
-perm_general_demo_addon[config] = Rechte für Demo-Addon-Konfiguration
+perm_general_demo_addon[] = demo_addon[] - Rechte für Demo-Addon
+perm_general_demo_addon[config] = demo_addon[config] - Rechte für Demo-Addon-Konfiguration

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -1,0 +1,30 @@
+# Da R5 nur noch mit UTF8 arbeitet, entfällt der "utf8"-Suffix
+
+# Die Keys sollten mit dem Addonnamen beginnen, da sie so innerhalb des Addons vereinfacht abgefragt werden können
+
+demo_addon_title = Demo-Addon
+
+demo_addon_main = Mainpage
+demo_addon_main_title = Demo-Addon title mainpage
+demo_addon_main_content = Content Demo-Addon-Page
+
+demo_addon_config = Settings
+demo_addon_config_legend1 = Simple Fields
+demo_addon_config_url = URL
+demo_addon_config_checkbox = Checkbox
+demo_addon_config_select = Select
+demo_addon_config_multiselect = Multiselect
+
+demo_addon_config_legend2 = Medianpool, Linkmap etc.
+demo_addon_config_file = File
+demo_addon_config_article = Article
+demo_addon_config_categories = Category select
+demo_addon_config_pageids = Page select
+
+demo_addon_config_save = Save settings
+demo_addon_config_saved = Settings saved!
+
+# Benennung für die Addonrechte, sichtbar innerhalb der REDAXO-Administration unter Benutzer > Rollen > Allgemein
+
+perm_general_demo_addon[] = demo_addon[] - Rights for Demo-Addon
+perm_general_demo_addon[config] = demo_addon[config] - Rights for Demo-Addon Settings

--- a/pages/config.php
+++ b/pages/config.php
@@ -1,71 +1,211 @@
 <?php
 
-/** @var rex_addon $this */
-
 $content = '';
+$buttons = '';
 
-if (rex_post('config-submit', 'boolean')) {
+// Einstellungen speichern
+if (rex_post('formsubmit', 'string') == '1') {
     $this->setConfig(rex_post('config', [
         ['url', 'string'],
-        ['ids', 'array[int]'],
+        ['checkbox', 'string'],
+        ['select', 'string'],
+        ['multiselect', 'array[int]'],
+        ['file', 'string'],
+        ['article', 'string'],
+        ['categories', 'array[int]'],
+        ['pageids', 'string'],
     ]));
 
-    $content .= rex_view::info($this->i18n('config_saved'));
+    echo rex_view::success($this->i18n('config_saved'));
 }
 
-$content .= '
-<div class="rex-form">
-    <form action="' . rex_url::currentBackendPage() . '" method="post">
-        <fieldset>';
+$content .= '<fieldset><legend>' . $this->i18n('config_legend1') . '</legend>';
 
+// Einfaches Textfeld
 $formElements = [];
-
 $n = [];
-$n['label'] = '<label for="rex-demo_addon-config-url">' . $this->i18n('config_url') . '</label>';
-$n['field'] = '<input class="form-control" type="text" id="rex-demo_addon-config-url" name="config[url]" value="' . $this->getConfig('url') . '"/>';
+$n['label'] = '<label for="demo_addon-config-url">' . $this->i18n('config_url') . '</label>';
+$n['field'] = '<input class="form-control" type="text" id="demo_addon-config-url" name="config[url]" value="' . $this->getConfig('url') . '"/>';
 $formElements[] = $n;
 
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
+
+// Checkbox
+$formElements = [];
 $n = [];
-$n['label'] = '<label for="rex-demo_addon-config-ids">' . $this->i18n('config_ids') . '</label>';
+$n['label'] = '<label for="demo_addon-config-checkbox">' . $this->i18n('config_checkbox') . '</label>';
+$n['field'] = '<input type="checkbox" id="demo_addon-config-checkbox" name="config[checkbox]"' . (!empty($this->getConfig('checkbox')) && $this->getConfig('checkbox') == '1' ? ' checked="checked"' : '') . ' value="1" />';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/checkbox.php');
+
+// Select
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="demo_addon-config-ids">' . $this->i18n('config_select') . '</label>';
 $select = new rex_select();
-$select->setId('rex-demo_addon-config-ids');
-$select->setMultiple();
+$select->setId('demo_addon-config-select');
 $select->setAttribute('class', 'form-control');
-$select->setName('config[ids][]');
-for ($i = 1; $i < 6; ++$i) {
-    $select->addOption($i, $i);
-}
-$select->setSelected($this->getConfig('ids'));
+$select->setName('config[select]');
+$select->addOption(0, 0);
+$select->addOption(1, 1);
+$select->setSelected($this->getConfig('select'));
 $n['field'] = $select->get();
 $formElements[] = $n;
 
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
-$content .= $fragment->parse('core/form/form.php');
+$content .= $fragment->parse('core/form/container.php');
 
-$content .= '
-        </fieldset>
-
-        <fieldset class="rex-form-action">';
-
+// Multiselect
 $formElements = [];
-
 $n = [];
-$n['field'] = '<input class="btn btn-save rex-form-aligned" type="submit" name="config-submit" value="' . $this->i18n('config_save') . '" ' . rex::getAccesskey($this->i18n('config_save'), 'save') . ' />';
+$n['label'] = '<label for="demo_addon-config-multiselect">' . $this->i18n('config_multiselect') . '</label>';
+$select = new rex_select();
+$select->setId('demo_addon-config-multiselect');
+$select->setMultiple();
+$select->setAttribute('class', 'form-control');
+$select->setName('config[multiselect][]');
+for ($i = 1; $i < 6; ++$i) {
+    $select->addOption($i, $i);
+}
+$select->setSelected($this->getConfig('multiselect'));
+$n['field'] = $select->get();
 $formElements[] = $n;
 
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
-$content .= $fragment->parse('core/form/submit.php');
+$content .= $fragment->parse('core/form/container.php');
 
-$content .= '
-        </fieldset>
+$content .= '</fieldset>';
 
-    </form>
-</div>';
+$content .= '<fieldset><legend>' . $this->i18n('config_legend2') . '</legend>';
 
+// Dateiauswahl Medienpool-Widget
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="REX_MEDIA_1">' . $this->i18n('config_file') . '</label>';
+
+$n['field'] = '
+<div class="rex-js-widget rex-js-widget-media">
+	<div class="input-group">
+		<input class="form-control" type="text" name="config[file]" value="' . $this->getConfig('file') . '" id="REX_MEDIA_1" readonly="readonly">
+		<span class="input-group-btn">
+        <a href="#" class="btn btn-popup" onclick="openREXMedia(1);return false;" title="'.$this->i18n('var_media_open').'">
+        	<i class="rex-icon rex-icon-open-mediapool"></i>
+        </a>
+        <a href="#" class="btn btn-popup" onclick="addREXMedia(1);return false;" title="'.$this->i18n('var_media_new').'">
+        	<i class="rex-icon rex-icon-add-media"></i>
+        </a>
+        <a href="#" class="btn btn-popup" onclick="deleteREXMedia(1);return false;" title="'.$this->i18n('var_media_remove').'">
+        	<i class="rex-icon rex-icon-delete-media"></i>
+        </a>
+        <a href="#" class="btn btn-popup" onclick="viewREXMedia(1);return false;" title="'.$this->i18n('var_media_view').'">
+        	<i class="rex-icon rex-icon-view-media"></i>
+        </a>
+        </span>
+	</div>
+ </div>
+';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
+
+// Artikel
+$formElements = [];
+$artname = '';
+$art = rex_article::get($this->getConfig('article'));
+if ($art) {
+    $artname = $art->getValue('name');
+}
+$n = [];
+$n['label'] = '<label for="REX_LINK_1_NAME">' . $this->i18n('config_article') . '</label>';
+$n['field'] = '
+<div class="rex-js-widget rex-js-widget-link">
+	<div class="input-group">	
+			<input class="form-control" type="text" name="REX_LINK_NAME[1]" value="'.$artname.'" id="REX_LINK_1_NAME" readonly="readonly" />
+			<input type="hidden" name="config[article]" id="REX_LINK_1" value="' . $this->getConfig('article') . '" />
+
+			<span class="input-group-btn">
+				<a href="#" class="btn btn-popup" onclick="openLinkMap(\'REX_LINK_1\', \'&clang=1&category_id=1\');return false;" title="' . $this->i18n('var_link_open') . '"><i class="rex-icon rex-icon-open-linkmap"></i></a>
+				<a href="#" class="btn btn-popup" onclick="deleteREXLink(1);return false;" title="' . $this->i18n('var_link_delete') . '"><i class="rex-icon rex-icon-delete-link"></i></a>
+			</span>
+    </div>
+</div>
+';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
+
+// Kategorienauswahl
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="demo_addon-config-categories">' . $this->i18n('config_categories') . '</label>';
+
+$category_select = new rex_category_select(false, false, false, true);
+$category_select->setName('config[categories][]');
+$category_select->setId('demo_addon-config-categories');
+$category_select->setSize('10');
+$category_select->setMultiple(true);
+$category_select->setAttribute('style', 'width:100%');
+$category_select->setSelected($this->getConfig('categories'));
+
+$n['field'] = $category_select->get();
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');	
+
+// Seitenauswahl
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="REX_LINKLIST_SELECT_1">' . $this->i18n('config_pageids') . '</label>';
+$n['field'] = rex_var_linklist::getWidget(1, 'config[pageids]', $this->getConfig('pageids'));
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
+
+$content .= '</fieldset>';
+
+// Save-Button
+$formElements = [];
+$n = [];
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="save" value="' . $this->i18n('config_save') . '">' . $this->i18n('config_save') . '</button>';
+$formElements[] = $n;
+
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$buttons = $fragment->parse('core/form/submit.php');
+$buttons = '
+<fieldset class="rex-form-action">
+    ' . $buttons . '
+</fieldset>
+';
+
+// Ausgabe Formular
 $fragment = new rex_fragment();
 $fragment->setVar('class', 'edit');
 $fragment->setVar('title', $this->i18n('config'));
 $fragment->setVar('body', $content, false);
-echo $fragment->parse('core/page/section.php');
+$fragment->setVar('buttons', $buttons, false);
+$output = $fragment->parse('core/page/section.php');
+
+$output = '
+<form action="' . rex_url::currentBackendPage() . '" method="post">
+<input type="hidden" name="formsubmit" value="1" />
+    ' . $output . '
+</form>
+';
+
+echo $output;

--- a/pages/index.php
+++ b/pages/index.php
@@ -1,13 +1,11 @@
 <?php
 
-/** @var rex_addon $this */
-
 // Die layout/top.php und layout/bottom.php werden automatisch eingebunden
 
 // Die Subpages müssen dem Titel nicht mehr übergeben werden
 echo rex_view::title($this->i18n('title')); // $this->i18n('title') ist eine Kurzform für rex_i18n::msg('demo_addon_title')
 
-// Die Subpages werden nicht mehr über den "subpage"-Parameter gesteuert, sondern mit über "page" (getrennt mit einem Slash, z. B. page=demo_addon/config)
+// Die Subpages werden nicht mehr über den "subpage"-Parameter gesteuert, sondern über "page" (getrennt mit einem Slash, z. B. page=demo_addon/config)
 // Die einzelnen Teile des page-Pfades können mit der folgenden Funktion ausgelesen werden.
 $subpage = rex_be_controller::getCurrentPagePart(2);
 

--- a/pages/main.php
+++ b/pages/main.php
@@ -1,8 +1,8 @@
 <?php
 
-$content = 'Allgemeine Demo-Addon-Seite';
+$content = $this->i18n('main_content');
 
 $fragment = new rex_fragment();
-$fragment->setVar('title', 'Demo-Addon Titel', false);
+$fragment->setVar('title', $this->i18n('main_title'), false);
 $fragment->setVar('body', $content, false);
 echo $fragment->parse('core/page/section.php');


### PR DESCRIPTION
Config-Page überarbeitet und mit Beispielen erweitert, Englische
Übersetzung, Texte aus PHP in .lang-Dateien, Meldung bei Config
ausserhalb des Blockes