### PR TITLE
Sprachwähler, CSRF-Schutz

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -22,7 +22,7 @@ page:
 # Abhängigkeiten
 # Anforderungen ans System oder anderere AddOns, um dieses AddOn installieren oder update zu können
 requires:
-    redaxo: '^5.3' # benötigt mindestens REDAXO 5.3
+    redaxo: '^5.5' # benötigt mindestens REDAXO 5.5
     packages:
         media_manager: '^2.0.1' # benötigt mindestens das Addon Media Manager 2.0.1
     php:

--- a/pages/config.php
+++ b/pages/config.php
@@ -3,8 +3,12 @@
 $content = '';
 $buttons = '';
 
+$csrfToken = rex_csrf_token::factory('demo_addon');
+
 // Einstellungen speichern
-if (rex_post('formsubmit', 'string') == '1') {
+if (rex_post('formsubmit', 'string') == '1' && !$csrfToken->isValid()) {
+    echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+} elseif (rex_post('formsubmit', 'string') == '1') {
     $this->setConfig(rex_post('config', [
         ['url', 'string'],
         ['checkbox', 'string'],
@@ -128,7 +132,7 @@ $n = [];
 $n['label'] = '<label for="REX_LINK_1_NAME">' . $this->i18n('config_article') . '</label>';
 $n['field'] = '
 <div class="rex-js-widget rex-js-widget-link">
-	<div class="input-group">	
+	<div class="input-group">
 			<input class="form-control" type="text" name="REX_LINK_NAME[1]" value="'.$artname.'" id="REX_LINK_1_NAME" readonly="readonly" />
 			<input type="hidden" name="config[article]" id="REX_LINK_1" value="' . $this->getConfig('article') . '" />
 
@@ -163,7 +167,7 @@ $formElements[] = $n;
 
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
-$content .= $fragment->parse('core/form/container.php');	
+$content .= $fragment->parse('core/form/container.php');
 
 // Seitenauswahl
 $formElements = [];
@@ -204,6 +208,7 @@ $output = $fragment->parse('core/page/section.php');
 $output = '
 <form action="' . rex_url::currentBackendPage() . '" method="post">
 <input type="hidden" name="formsubmit" value="1" />
+    ' . $csrfToken->getHiddenField() . '
     ' . $output . '
 </form>
 ';

--- a/plugins/documentation/assets/documentation.css
+++ b/plugins/documentation/assets/documentation.css
@@ -138,3 +138,13 @@
   content: "\f08e";
   margin-left: 5px;
 }
+
+/* Sprachwähler */
+.addon_documentation #doclang {
+  width: 70px;
+  position: absolute;
+  right: 20px;
+  top: 6px;
+  padding: 5px 0;
+}
+

--- a/plugins/documentation/pages/index.php
+++ b/plugins/documentation/pages/index.php
@@ -30,43 +30,42 @@ $lang = rex::getUser()->getLanguage();
 if ($plugin->getProperty('documentationlang')) {
     $lang = $plugin->getProperty('documentationlang');
     $_SESSION['addon_documentation']['doclang'] = $lang;
-} else {
+}
+
 // Bei mehreren verfügbaren Sprachen Sprachwähler aufbauen
-    $docs = [];
-    $path = rex_path::plugin($addon, $docplugin , 'docs/');
-    foreach (scandir($path) as $i_file) {
-        if ($i_file != '.' && $i_file != '..') {
-            if (is_dir($path . $i_file) && file_exists($path . $i_file . '/' . $default_navi)) {
-                $docs[$i_file] = $i_file;
-            }
+$docs = [];
+$path = rex_path::plugin($addon, $docplugin , 'docs/');
+foreach (scandir($path) as $i_file) {
+    if ($i_file != '.' && $i_file != '..') {
+        if (is_dir($path . $i_file) && file_exists($path . $i_file . '/' . $default_navi)) {
+         $docs[$i_file] = $i_file;
         }
     }
-    if (count($docs) > 1) {
-        if (isset($_SESSION['addon_documentation']['doclang'])) {
-            $lang = $_SESSION['addon_documentation']['doclang'];
-        }
-        if ($doclang) {
-            $lang = $doclang;
-        }
-        $sel_lang = new rex_select();
-        $sel_lang->setStyle('class="form-control"');
-        $sel_lang->setName('doclang');
-        $sel_lang->setId('doclang');
-        $sel_lang->setSize(1);
-        $sel_lang->setSelected($lang);
-        foreach ($docs as $l) {
-            $sel_lang->addOption($l, $l);
-        }
-        //$langselect = $sel_lang->get();
-        $langselect = '
-        <form action="' . rex_url::currentBackendPage() . '" method="post">
-        <input type="hidden" name="formsubmit" value="1" />
-            ' . $sel_lang->get() . '
-        </form>
-        ';
-        if ($formsubmit) {
-            $_SESSION['addon_documentation']['doclang'] = $lang;
-        }
+}
+if (count($docs) > 1) {
+    if (isset($_SESSION['addon_documentation']['doclang'])) {
+        $lang = $_SESSION['addon_documentation']['doclang'];
+    }
+    if ($doclang) {
+        $lang = $doclang;
+    }
+    $sel_lang = new rex_select();
+    $sel_lang->setStyle('class="form-control"');
+    $sel_lang->setName('doclang');
+    $sel_lang->setId('doclang');
+    $sel_lang->setSize(1);
+    $sel_lang->setSelected($lang);
+    foreach ($docs as $l) {
+        $sel_lang->addOption($l, $l);
+    }
+    $langselect = '
+    <form action="' . rex_url::currentBackendPage() . '" method="post">
+    <input type="hidden" name="formsubmit" value="1" />
+        ' . $sel_lang->get() . '
+    </form>
+    ';
+    if ($formsubmit) {
+        $_SESSION['addon_documentation']['doclang'] = $lang;
     }
 }
 
@@ -197,7 +196,7 @@ $content = $fragment->parse('core/page/section.php');
 echo '
 <section class="addon_documentation">
     <div class="row">
-        <div class="col-md-4 addon_documentation-navi">' . $navi . $langselect . '
+        <div class="col-md-4 addon_documentation-navi">' . $langselect . $navi . '
         </div>
         <div class="col-md-8 addon_documentation-content">' . $content . '
         </div>


### PR DESCRIPTION
Sprachwähler (documentation-plugin) bei mehreren vorhanden Sprachen der Dokumentationen anzeigen. Position oben rechts in der Navigation.

CSRF-Schutz Einstellungen-Seite (pages/config.php)
REDAXO-Version auf 5.5 gesetzt