### PR TITLE
php version for php 8

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -86,7 +86,7 @@ requires:
   packages:
     media_manager: "^2.0.1" # benötigt mindestens das AddOn Media Manager 2.0.1
   php:
-    version: "^7.3" # benötigt mindestens PHP 7.3
+    version: ">=7.3" # benötigt mindestens PHP 7.3
     extensions: [gd, xml] # benötigt die PHP-Extensions GDlib und XML
 
 # Plugins die automatisch installiert werden sollen


### PR DESCRIPTION
The version "^7.3" lead to an install error with systems running PHP 8.x