### PR TITLE
Update PACKAGES_INCLUDED.php

### DIFF
--- a/pages/extensionpoints/core/PACKAGES_INCLUDED.php
+++ b/pages/extensionpoints/core/PACKAGES_INCLUDED.php
@@ -7,6 +7,9 @@ rex_extension::register('PACKAGES_INCLUDED', static function (rex_extension_poin
 
     // Modus und URL für die Logfile-Ausgabe
     $rxmode = (rex::isBackend() && rex::getUser()) ? 'Backend' : 'Frontend';
-    $url = $_SERVER['REQUEST_URI'];
-    demo_addon_logger::log('Mode: ' . $rxmode . '<br>URL: ' . $url, $ep->getName());
+        $url = 'run via CLI';
+    if (isset($_SERVER['REQUEST_URI'])) {
+        $url = 'URL: ' . $_SERVER['REQUEST_URI'];
+    }
+    demo_addon_logger::log('Mode: ' . $rxmode . '<br> ' . $url, $ep->getName());
 });


### PR DESCRIPTION
System Log got spammed with "Notice, Undefined index: REQUEST_URI, File: redaxo/src/addons/demo_addon/pages/extensionpoints/core/PACKAGES_INCLUDED.php, Row: 10".

$_SERVER['REQUEST_URI'] doesn't get filled when run via CLI.